### PR TITLE
devfreq command added

### DIFF
--- a/perlfc.pl
+++ b/perlfc.pl
@@ -629,6 +629,7 @@ sub f_regulator
 		$reg_dev_addr = $line;
 		print "$line";
 		print $brfd "===========\n";
+		print $brfd "regulator_dev =  0x$reg_dev_addr";
 
 		# get size of array
 		my $array_size = @element_array;


### PR DESCRIPTION
commit 1a69fa5219bd56b9aa3dc3b9a52b3d4f3a820243
Author: Arun KS <arunks@codeaurora.org>
Date:   Tue May 12 11:58:40 2015 +0530

    perlfd: print regulator_dev address aswell

    regulator_dev address is required sometimes.
    Add it as a part of regulator command.

    Signed-off-by: Arun KS <getarunks@gmail.com>

commit 6612c8929f8111841718590c796f2e91172aa198
Author: Arun KS <arunks@codeaurora.org>
Date:   Tue May 12 10:54:48 2015 +0530

    perlfd: Add devfreq command

    This command prints the device name, governor_name, max_freq,
    min_freq and previous_freq for all the devfreq devices in the
    system.

    New members can be added by editing the element_array

    Signed-off-by: Arun KS <getarunks@gmail.com>
